### PR TITLE
Try to get CLC e2e tests to succeed

### DIFF
--- a/pkg/tests/import_cluster/import_cluster_test.go
+++ b/pkg/tests/import_cluster/import_cluster_test.go
@@ -67,9 +67,17 @@ var _ = Describe("Cluster-lifecycle: [P1][Sev1][cluster-lifecycle] Import cluste
 
 			Eventually(func() error {
 				_, _, err := libgodeploymentv1.HasDeploymentsInNamespace(hubClients.KubeClient,
-					"open-cluster-management",
+					"multicluster-engine",
 					[]string{
 						"managedcluster-import-controller-v2",
+					})
+				return err
+			}).Should(BeNil())
+
+			Eventually(func() error {
+				_, _, err := libgodeploymentv1.HasDeploymentsInNamespace(hubClients.KubeClient,
+					"open-cluster-management",
+					[]string{
 						"klusterlet-addon-controller-v2",
 					})
 				return err

--- a/pkg/tests/import_cluster/import_hub_test.go
+++ b/pkg/tests/import_cluster/import_hub_test.go
@@ -44,9 +44,17 @@ var _ = Describe("Cluster-lifecycle: [P1][Sev1][cluster-lifecycle] Check local-c
 
 		Eventually(func() error {
 			_, _, err := libgodeploymentv1.HasDeploymentsInNamespace(hubClients.KubeClient,
-				"open-cluster-management",
+				"multicluster-engine",
 				[]string{
 					"managedcluster-import-controller-v2",
+				})
+			return err
+		}).Should(BeNil())
+
+		Eventually(func() error {
+			_, _, err := libgodeploymentv1.HasDeploymentsInNamespace(hubClients.KubeClient,
+				"open-cluster-management",
+				[]string{
 					"klusterlet-addon-controller-v2",
 				})
 			return err

--- a/pkg/tests/metrics/metrics_test.go
+++ b/pkg/tests/metrics/metrics_test.go
@@ -57,7 +57,7 @@ var prometheusQueryURL string
 
 var _ = Describe("Cluster-lifecycle: [P2][Sev1][cluster-lifecycle] Check metrics", func() {
 	BeforeEach(func() {
-		prometheusQueryURL = fmt.Sprintf("%s.%s/%s", prometheusServiceURL, options.BaseDomain, metricQueryURI)
+		prometheusQueryURL = fmt.Sprintf("%s.%s.%s/%s", prometheusServiceURL, options.ClusterName, options.BaseDomain, metricQueryURI)
 		SetDefaultEventuallyTimeout(1 * time.Minute)
 		SetDefaultEventuallyPollingInterval(10 * time.Second)
 	})
@@ -154,5 +154,5 @@ func getMetricsQuery(queryExpression string) (resp *http.Response, body []byte, 
 			log.Fatal(err)
 		}
 	}
-	return
+	return resp, body, err
 }

--- a/pkg/tests/options/options.go
+++ b/pkg/tests/options/options.go
@@ -15,6 +15,7 @@ import (
 var BaseDomain string
 var KubeadminUser string
 var KubeadminCredential string
+var ClusterName string
 
 func InitVars() error {
 
@@ -26,6 +27,10 @@ func InitVars() error {
 
 	if libgooptions.TestOptions.Options.Hub.KubeConfig == "" {
 		libgooptions.TestOptions.Options.Hub.KubeConfig = os.Getenv("KUBECONFIG")
+	}
+
+	if libgooptions.TestOptions.Options.Hub.Name != "" {
+		ClusterName = libgooptions.TestOptions.Options.Hub.Name
 	}
 
 	if libgooptions.TestOptions.Options.Hub.BaseDomain != "" {

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -143,9 +143,20 @@ with image %s ===============================`, clusterName, imageRefName)
 
 			Eventually(func() bool {
 				has, missing, _ := libgodeploymentv1.HasDeploymentsInNamespace(hubClients.KubeClient,
-					"open-cluster-management",
+					"multicluster-engine",
 					[]string{
 						"managedcluster-import-controller-v2",
+					})
+				if !has {
+					klog.Errorf("Cluster %s: Missing deployments\n%#v", clusterName, missing)
+				}
+				return has
+			}).Should(BeTrue())
+
+			Eventually(func() bool {
+				has, missing, _ := libgodeploymentv1.HasDeploymentsInNamespace(hubClients.KubeClient,
+					"open-cluster-management",
+					[]string{
 						"klusterlet-addon-controller-v2",
 					})
 				if !has {
@@ -823,7 +834,7 @@ func DestroyCluster(cloud, vendor, cloudProviders string) {
 
 			Eventually(func() bool {
 				has, missing, _ := libgodeploymentv1.HasDeploymentsInNamespace(hubClients.KubeClient,
-					"open-cluster-management",
+					"multicluster-engine",
 					[]string{"managedcluster-import-controller-v2"})
 				if !has {
 					klog.Errorf("Cluster %s: Missing deployments\n%#v", clusterName, missing)


### PR DESCRIPTION
Signed-off-by: Zachary Kayyali <zkayyali@redhat.com>

This PR attempts to make the fixes required to enable the CLC e2e tests to succeed in the canaries per issue https://github.com/stolostron/backlog/issues/19914

Per my attempts, I was still not able to get these tests to succeed, I am not sure what is missing here. It may require someone with more experience in CLC/this repo to validate.

The tests seem to have broken after the migration of CLC components from ACM to MCE.

In this PR, I ensured the namespace of `multicluster-engine` for the migrated deployments, and attempted to fix another bug with the prometheus route generation.

Would appreciate if CLC squad can take a look and see what is missing here to try to get the e2e tests to succeed as expected.
